### PR TITLE
Fix garbled characters in camera device names

### DIFF
--- a/src/apple/camera_feed_apple.h
+++ b/src/apple/camera_feed_apple.h
@@ -9,6 +9,7 @@
 
 #include "godot_cpp/classes/image.hpp"
 #include "godot_cpp/variant/dictionary.hpp"
+#include "godot_cpp/variant/string.hpp"
 #include "godot_cpp/variant/typed_array.hpp"
 
 using namespace godot;

--- a/src/apple/camera_feed_apple.mm
+++ b/src/apple/camera_feed_apple.mm
@@ -54,7 +54,7 @@ AVCaptureDevice *CameraFeedApple::get_device() const {
 void CameraFeedApple::set_this(CameraFeedExtension *p_feed) {
 	this_ = p_feed;
 	delegate = [[OutputDelegate alloc] init:this_];
-	this_->set_name(device.localizedName.UTF8String);
+	this_->set_name(godot::String::utf8(device.localizedName.UTF8String));
 	godot::CameraFeed::FeedPosition position = godot::CameraFeed::FeedPosition::FEED_UNSPECIFIED;
 	if (device.position == AVCaptureDevicePositionFront) {
 		position = godot::CameraFeed::FeedPosition::FEED_FRONT;


### PR DESCRIPTION
The type of the set_name argument is godot::String.
Non-ASCII characters will be garbled due to incorrect character encoding.
